### PR TITLE
Use /etc/apt/keyrings for mopidy key

### DIFF
--- a/github/ci/Dockerfile
+++ b/github/ci/Dockerfile
@@ -31,8 +31,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Enable apt.mopidy.com repo
-RUN mkdir -p /usr/local/share/keyrings \
-    && wget -q -O /usr/local/share/keyrings/mopidy-archive-keyring.gpg https://apt.mopidy.com/mopidy.gpg \
+RUN mkdir -p /etc/apt/keyrings \
+    && wget -q -O /etc/apt/keyrings/mopidy-archive-keyring.gpg https://apt.mopidy.com/mopidy.gpg \
     && wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/bookworm.list
 
 # Allow git to work with directories owned by other users


### PR DESCRIPTION
This fix is required since the current key path in the container (/usr/local/share/keyrings/mopidy-archive-keyring.gpg) doesn't match the key path we use at https://apt.mopidy.com/bookworm.list (/etc/apt/keyrings/mopidy-archive-keyring.gpg):
```
# Mopidy APT archive
# Built on Debian 11 (bullseye), compatible with Ubuntu 22.04 LTS and newer
deb [signed-by=/etc/apt/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free
deb-src [signed-by=/etc/apt/keyrings/mopidy-archive-keyring.gpg] https://apt.mopidy.com/ bullseye main contrib non-free
```
If you start the container and try an `apt update` it falls over with key error.